### PR TITLE
Remove unused, broken argument

### DIFF
--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -360,5 +360,4 @@ class WorkerConfiguration(LoggingMixin):
             tolerations=tolerations,
             security_context=self._get_security_context(),
             configmaps=self._get_configmaps(),
-            host_aliases=self._get_host_aliases()
         )


### PR DESCRIPTION
We specify host aliases via the `KubernetesPodOperator`, they aren't a configuration input to airflow workers.

`Pod` has a default arg for `host_aliases` (the empty list), so not specifying it is safe.